### PR TITLE
Logger für die Inventar anzeige angepasst

### DIFF
--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -286,6 +286,7 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
                                 .append(": ")
                                 .append(bag.getItemsInBag().get(i).getItemName());
                     }
+                    gameLogger.info(logMessageBag.toString());
                     if (!bag.isEmpty()) {
                         int in = sc.nextInt();
                         if (in >= 0 && in < bag.getItemsInBag().size()) {


### PR DESCRIPTION
Das Inventar wurden nicht richtig angezeigt, wenn man eine Tasche auswählt.

Das Inventar der Tasche wird nun durch den Logger richtig ausgegeben.